### PR TITLE
ci: add required check job for merge gating

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -11,6 +11,8 @@ This repository publishes generated assets and an action bundle. CI correctness 
      - install (`npm ci`)
      - build (`npm run build`)
      - tests (`npm test`)
+     - workflow YAML lint (`actionlint`)
+     - composite-action smoke (`uses: ./action` with sample mode)
 
 2. Bundle drift prevention
    - If `action/index.mjs` is tracked, ensure workflow detects stale bundle after build.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: rhysd/actionlint@v1
+      # Pinned release (there is no floating `v1` tag for this action).
+      - uses: rhysd/actionlint@v1.7.12
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,13 @@ permissions:
   contents: read
 
 jobs:
+  # Rulesets / branch protection: require the job name `validate` (not the workflow name).
   validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+
+      - uses: rhysd/actionlint@v1
 
       - uses: actions/setup-node@v5
         with:
@@ -26,10 +29,15 @@ jobs:
       - run: npm test
       - run: git diff --exit-code action/index.mjs
 
-  # Single check name for branch protection: require "CI / CI required" on `main`.
-  required:
-    name: CI required
-    needs: validate
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "CI passed"
+      - name: Smoke test composite action (offline sample)
+        uses: ./action
+        with:
+          github_user_name: sample
+          outputs: |
+            tmp/ci-smoke/tetrass.svg
+            tmp/ci-smoke/tetrass-dark.svg?palette=github-dark
+        env:
+          TETRASS_USE_SAMPLE: "1"
+
+      - name: Verify smoke outputs exist
+        run: test -s tmp/ci-smoke/tetrass.svg && test -s tmp/ci-smoke/tetrass-dark.svg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,11 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: git diff --exit-code action/index.mjs
+
+  # Single check name for branch protection: require "CI / CI required" on `main`.
+  required:
+    name: CI required
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "CI passed"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+tmp/
 dist/
 *.log
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,15 @@ This repository generates **deterministic animated SVGs** of that Overview-equiv
 
 CI alone does not block merges until the repository enforces it.
 
-1. Open **Settings → Rules → Rulesets** (or **Branches → Branch protection rules** on classic UI).
-2. Add a ruleset (or rule) for `main` that **requires status checks before merge**.
-3. Require the check named **`CI / CI required`** (workflow `CI`, job `required` with display name `CI required`). After the first successful run, it appears in the status-check picker.
-4. Optionally turn on **Require branches to be up to date before merging** so the tip of the branch was tested.
+For **Rulesets**, the status-check picker lists **job names** from GitHub Actions (e.g. **`validate`** for `.github/workflows/ci.yml`), not the workflow file name and not a `workflow / job` string unless your UI shows that exact label.
+
+**Recommended for this repo:** require **`validate`**. It is the only job that runs the real checks (`npm ci`, `npm run build`, `npm test`, bundle drift).
+
+Do **not** point branch protection at a downstream job that only has `needs: [validate]` and no `if: ${{ always() }}`: if `validate` fails, that job is **skipped**, and skipped checks can still allow a merge. If you ever add a wrapper job that must gate merges by name, use `if: ${{ always() }}` and fail the step when `needs.validate.result != 'success'` (see GitHub Actions docs on required checks).
+
+Solo baseline ruleset knobs often include: **Require a pull request before merging**, **Require status checks to pass** (with **`validate`** added), **Block force pushes**, **Restrict deletions**. Optionally **Require branches to be up to date before merging**.
+
+If you add more workflows later, keep **job ids unique across workflows**; generic names like `validate` can collide and confuse required-check selection.
 
 ## Review guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,15 @@ This repository generates **deterministic animated SVGs** of that Overview-equiv
 - Build TS + action bundle: `npm run build`
 - Tests: `npm test`
 
+## Merge gating (GitHub)
+
+CI alone does not block merges until the repository enforces it.
+
+1. Open **Settings → Rules → Rulesets** (or **Branches → Branch protection rules** on classic UI).
+2. Add a ruleset (or rule) for `main` that **requires status checks before merge**.
+3. Require the check named **`CI / CI required`** (workflow `CI`, job `required` with display name `CI required`). After the first successful run, it appears in the status-check picker.
+4. Optionally turn on **Require branches to be up to date before merging** so the tip of the branch was tested.
+
 ## Review guidelines
 
 Prioritize **P0/P1** regressions for correctness and safety.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ This repository generates **deterministic animated SVGs** of that Overview-equiv
 
 CI alone does not block merges until the repository enforces it.
 
-For **Rulesets**, the status-check picker lists **check names** shown by GitHub Actions (for this repo, require **`CI / CI required`**), not the workflow file name.
+For **Rulesets**, the status-check picker lists **job names** from GitHub Actions (e.g. **`validate`** for `.github/workflows/ci.yml`), not the workflow file name and not a `workflow / job` string unless your UI shows that exact label.
 
-**Recommended for this repo:** require **`CI / CI required`** as the single merge gate. It should pass only after real checks (`npm ci`, `npm run build`, `npm test`, bundle drift) succeed.
+**Recommended for this repo:** require **`validate`**. It is the only job that runs the real checks (`npm ci`, `npm run build`, `npm test`, bundle drift).
 
 Do **not** point branch protection at a downstream job that only has `needs: [validate]` and no `if: ${{ always() }}`: if `validate` fails, that job is **skipped**, and skipped checks can still allow a merge. If you ever add a wrapper job that must gate merges by name, use `if: ${{ always() }}` and fail the step when `needs.validate.result != 'success'` (see GitHub Actions docs on required checks).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ This repository generates **deterministic animated SVGs** of that Overview-equiv
 
 CI alone does not block merges until the repository enforces it.
 
-For **Rulesets**, the status-check picker lists **job names** from GitHub Actions (e.g. **`validate`** for `.github/workflows/ci.yml`), not the workflow file name and not a `workflow / job` string unless your UI shows that exact label.
+For **Rulesets**, the status-check picker lists **check names** shown by GitHub Actions (for this repo, require **`CI / CI required`**), not the workflow file name.
 
-**Recommended for this repo:** require **`validate`**. It is the only job that runs the real checks (`npm ci`, `npm run build`, `npm test`, bundle drift).
+**Recommended for this repo:** require **`CI / CI required`** as the single merge gate. It should pass only after real checks (`npm ci`, `npm run build`, `npm test`, bundle drift) succeed.
 
 Do **not** point branch protection at a downstream job that only has `needs: [validate]` and no `if: ${{ always() }}`: if `validate` fails, that job is **skipped**, and skipped checks can still allow a merge. If you ever add a wrapper job that must gate merges by name, use `if: ${{ always() }}` and fail the step when `needs.validate.result != 'success'` (see GitHub Actions docs on required checks).
 


### PR DESCRIPTION
## Overview

Add a dedicated trailing CI job with a stable check name, and document how to enforce it on `main` so merges require a green workflow.

## Purpose

GitHub does not block merges on CI until branch protection / rulesets require status checks. This PR makes that setup straightforward by exposing a single required check: **`CI / CI required`**.

## Implementation Summary

- **`.github/workflows/ci.yml`**: Add `required` job (`needs: validate`) that succeeds only after build, tests, and bundle drift checks pass.
- **`AGENTS.md`**: Add **Merge gating (GitHub)** steps (rulesets or classic branch protection).

## Post-merge (maintainers)

In repo settings, require the status check **`CI / CI required`** for `main` (after this workflow has run successfully at least once on a PR).

## Out of scope

- Enabling branch protection via API or org defaults (must be done in GitHub Settings).

## Related

- Commit: `ci: add required check job for merge gating`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/daisukekarasawa/tetrass/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CIにワークフローLintとローカルアクションのスモークテストを追加し、マージ前の検証を強化しました（サンプル実行と生成アセットの存在確認を含む）。
  * 一時出力ディレクトリをGit無視設定に追加しました。

* **Documentation**
  * ブランチ保護ルールセットやマージゲーティングの設定方法（必要チェックの選び方、注意点、ジョブ名ベースの指定の推奨）を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->