### PR TITLE
hardening: fail fast for missing action workspace and O_NOFOLLOW

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -108,10 +108,19 @@ reviews:
       - name: "Action contract docs sync"
         mode: "warning"
         instructions: |
-          Apply when PR changes action/action.yml inputs or output query semantics in
-          src/generateRunner.ts parseOutputLines.
-          Pass only if README usage snippet and Inputs section are updated consistently.
-          Fail when contract changed but README remains stale.
+          Contract location (mandatory): The GitHub Action manifest is **action/action.yml**
+          (composite action in subdirectory). There is **no** action.yml at the repository root
+          by design. **Never** mark this check Inconclusive solely because ./action.yml or
+          ./action.yaml is missing at the root; always read **action/action.yml** for the
+          inputs/outputs contract.
+
+          Step 1 — Scope: If the PR does not modify action/action.yml, README.md, or
+          src/generateRunner.ts (outputs / parseOutputLines semantics), **Pass** with reason
+          "N/A: action contract and docs paths unchanged."
+
+          Step 2 — When action/action.yml or relevant generator output parsing changes: verify
+          README usage snippet and Inputs section match the manifest. **Fail** if README is
+          stale; **Pass** when consistent.
 
       - name: "Output path boundary guard"
         mode: "warning"

--- a/action/index.mjs
+++ b/action/index.mjs
@@ -1,6 +1,6 @@
 // src/generateRunner.ts
 import { constants as fsConstants, existsSync, realpathSync } from "node:fs";
-import { lstat, mkdir, open, writeFile } from "node:fs/promises";
+import { mkdir, open, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 // src/domain/grass.ts
@@ -744,16 +744,9 @@ function isErrnoCode(e, code) {
 }
 async function writeUtf8FileRejectSymlinkTarget(filePath, data) {
   if (fsConstants.O_NOFOLLOW === void 0) {
-    try {
-      const st = await lstat(filePath);
-      if (st.isSymbolicLink()) {
-        throw new Error(`Refusing to write through symbolic link: '${filePath}'`);
-      }
-    } catch (e) {
-      if (!isErrnoCode(e, "ENOENT")) throw e;
-    }
-    await writeFile(filePath, data, "utf8");
-    return;
+    throw new Error(
+      "O_NOFOLLOW is not available on this platform. Symlink-safe writes require Linux or macOS."
+    );
   }
   const flags = fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW;
   let handle;
@@ -811,7 +804,12 @@ function resolveGenerateOptions(env, args) {
     throw new Error("Invalid GitHub username format.");
   }
   const outputsRaw = env.INPUT_OUTPUTS ?? "";
-  const workspace = env.GITHUB_WORKSPACE ?? process.cwd();
+  const workspace = env.GITHUB_WORKSPACE?.trim();
+  if (!workspace) {
+    throw new Error(
+      "GITHUB_WORKSPACE is not set. This action must run inside a GitHub Actions environment."
+    );
+  }
   const outputs = parseOutputLines(outputsRaw, workspace);
   if (outputs.length === 0) {
     throw new Error("INPUT_OUTPUTS must list at least one output path.");

--- a/src/generateRunner.ts
+++ b/src/generateRunner.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants, existsSync, realpathSync } from "node:fs";
-import { lstat, mkdir, open, writeFile } from "node:fs/promises";
+import { mkdir, open, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import {
@@ -237,16 +237,9 @@ function isErrnoCode(e: unknown, code: string): boolean {
 
 async function writeUtf8FileRejectSymlinkTarget(filePath: string, data: string): Promise<void> {
   if (fsConstants.O_NOFOLLOW === undefined) {
-    try {
-      const st = await lstat(filePath);
-      if (st.isSymbolicLink()) {
-        throw new Error(`Refusing to write through symbolic link: '${filePath}'`);
-      }
-    } catch (e) {
-      if (!isErrnoCode(e, "ENOENT")) throw e;
-    }
-    await writeFile(filePath, data, "utf8");
-    return;
+    throw new Error(
+      "O_NOFOLLOW is not available on this platform. Symlink-safe writes require Linux or macOS.",
+    );
   }
 
   const flags =

--- a/src/resolveGenerateOptions.test.ts
+++ b/src/resolveGenerateOptions.test.ts
@@ -54,6 +54,19 @@ describe("resolveGenerateOptions", () => {
       ).toThrow(/GITHUB_TOKEN is required/);
     });
 
+    it("requires GITHUB_WORKSPACE in github-action context", () => {
+      expect(() =>
+        resolveGenerateOptions(
+          {
+            INPUT_GITHUB_USER_NAME: "octocat",
+            INPUT_OUTPUTS: "./img/a.svg",
+            GITHUB_TOKEN: "tok",
+          },
+          { context: "github-action" },
+        ),
+      ).toThrow(/GITHUB_WORKSPACE is not set/);
+    });
+
     it("returns options when valid", () => {
       const opts = resolveGenerateOptions(
         {

--- a/src/resolveGenerateOptions.ts
+++ b/src/resolveGenerateOptions.ts
@@ -60,7 +60,12 @@ export function resolveGenerateOptions(
   }
 
   const outputsRaw = env.INPUT_OUTPUTS ?? "";
-  const workspace = env.GITHUB_WORKSPACE ?? process.cwd();
+  const workspace = env.GITHUB_WORKSPACE?.trim();
+  if (!workspace) {
+    throw new Error(
+      "GITHUB_WORKSPACE is not set. This action must run inside a GitHub Actions environment.",
+    );
+  }
   const outputs = parseOutputLines(outputsRaw, workspace);
   if (outputs.length === 0) {
     throw new Error("INPUT_OUTPUTS must list at least one output path.");


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/daisukekarasawa/tetrass/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ファイル書き込み時のシンボリックリンク対策を強化し、サポートされない環境では即時エラーを返すようになりました。
  * GitHub Actions環境の検証を厳格化し、ワークスペース情報が欠落または空白の場合にエラーを発生させます。

* **Tests**
  * 上記環境変数検証を確認する新しいテストケースを追加しました。

* **Chores**
  * プリマージの契約ドキュメントチェック手順を明確化・強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->