### PR TITLE
docs: slim README to user-facing setup and embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # Tetrass
 
-Deterministic (no randomness) **animated GitHub contribution graph** (“grass”) as SVG for your profile README.
+**Animated contribution graph (“grass”)** as SVG for your GitHub profile README. The picture matches your profile **Overview** heatmap (same days, same activity levels); only a drop-style animation is added on top.
 
-**Premise:** the static heatmap is the same as on your GitHub profile **Overview** — **53×7** visible cells, one square per day, **`contributionLevel` → four green intensities** (`0..4`) in the same positions. Animation is layered on that board only; it does not change which days are empty vs coloured or their levels.
+## Update SVGs with GitHub Actions
 
-Animation: the year is split into **nine vertical bands** — eight **`6×7`** blocks and one **`5×7`** block (left → right). Each band **drops from above** with internal day positions fixed; bands run **sequentially** so earlier weeks land before later ones. The discrete timeline is built by [`src/grass/scriptedDropPlanner.ts`](src/grass/scriptedDropPlanner.ts) (per-week-column falls merged in lockstep within each band). See [`AGENTS.md`](AGENTS.md) for board vs band-local coordinates (`row 1` = Sunday).
+Add a workflow that runs this repo’s **composite action**, then commits the generated files (similar to [Platane/snk](https://github.com/Platane/snk)).
 
-## Use from your profile repository (recommended, snk-style)
-
-Add a workflow that calls this repo’s **composite action** (same idea as [Platane/snk](https://github.com/Platane/snk)): one step generates SVGs; another commits them.
-
-Replace `DaisukeKarasawa/tetrass` and `@main` with this repository and the branch or tag you want to pin.
+Replace `DaisukeKarasawa/tetrass` and `@main` with the repository and ref you want to pin.
 
 ```yaml
 name: Generate Tetrass
@@ -42,113 +38,47 @@ jobs:
           file_pattern: "img/*.svg"
 ```
 
-**Inputs**
+You do **not** need `npm ci` in this workflow. The action uses the job’s default `GITHUB_TOKEN` to read your public contribution calendar.
+
+### Inputs
 
 | Input | Required | Description |
 |--------|----------|-------------|
-| `github_user_name` | yes | GitHub login whose public contribution calendar is used (strict week-grid correspondence). |
-| `outputs` | yes | Multiline paths relative to the repo root. Append `?palette=github-dark` for the dark theme (snk-compatible naming). |
+| `github_user_name` | yes | GitHub username whose **public** contribution calendar is drawn (usually `${{ github.repository_owner }}`). |
+| `outputs` | yes | One path per line, relative to the repo root. Add `?palette=github-dark` on a line for a dark-theme SVG (e.g. `img/tetrass-dark.svg?palette=github-dark`). |
 
-The action runs `node` on a bundled script; it does **not** require `npm ci` in the consumer workflow.
+## Embed in your profile README
 
-## README embed
-
-Replace `YOUR_USER` and `YOUR_REPO` with your GitHub username and profile repo name:
+Replace `YOUR_USER`, `YOUR_REPO`, and `main` with your account, profile repository name, and default branch:
 
 ```html
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/YOUR_USER/YOUR_REPO/main/img/tetrass-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/YOUR_USER/YOUR_REPO/main/img/tetrass.svg">
-  <img alt="Tetrass contribution animation" src="https://raw.githubusercontent.com/YOUR_USER/YOUR_REPO/main/img/tetrass.svg">
+  <img alt="Contribution activity animation" src="https://raw.githubusercontent.com/YOUR_USER/YOUR_REPO/main/img/tetrass.svg">
 </picture>
 ```
 
-Use your default branch name in place of `main` if it differs.
+Light and dark are **two files**; the HTML above picks the right one for the visitor’s theme.
 
-## How it works
+## Optional: generate on your own computer
 
-1. Fetches the contribution calendar from the GitHub GraphQL API (`contributionCount` + **`contributionLevel`**) — the same fields Overview uses. The composite action uses `GITHUB_TOKEN` (`github.token`) and fails fast if it is missing unless you enable sample/offline mode. Locally, provide `GITHUB_TOKEN` for real data, set `TETRASS_USE_SAMPLE=1` (or `TETRASS_OFFLINE=1`) for offline sample data, or set `TETRASS_ALLOW_UNAUTH_FALLBACK=1` (CLI only) to allow a sample fallback when an unauthenticated fetch fails.
-2. Maps contributions to a GitHub-native weekly grid: **x = week index, y = weekday**, **53 visible weeks** (right-aligned when history is shorter), so the level board matches Overview placement.
-3. Splits columns into **nine bands** `6+6+6+6+6+6+6+6+5` and builds a **fixed timeline** of discrete SMIL steps (no Tetris / line-clear simulation).
-4. Renders **static SVG files** (not Canvas): each cell is a rounded rect; **light** and **dark** are **separate outputs** (use a `<picture>` / `prefers-color-scheme` embed as in this README), not a single file with `@media (prefers-color-scheme: dark)` inside the SVG.
-5. Writes the SVG files you listed under `outputs`.
-
-Compared to projects like [Platane/snk](https://github.com/Platane/snk) (Canvas demo + CSS-variable SVG + snake path), Tetrass focuses on **Overview-faithful levels and grid** and a **nine-band drop** animation only.
-
-## Local generation (this repo / development)
+If you **clone this repository** and want SVGs locally:
 
 ```bash
 npm ci
 npm run build
-export GITHUB_TOKEN=ghp_...   # required for real contribution data (recommended in CI)
+export GITHUB_TOKEN=ghp_...   # personal token with permission to read your user via the API
 export GITHUB_LOGIN=yourname  # or GITHUB_REPOSITORY_OWNER
 npm run generate:tetrass
 ```
 
-Default output paths are `img/tetrass.svg` and `img/tetrass-dark.svg`. Override with `TETRASS_OUTPUTS` (same multiline format as the action):
+By default this writes `img/tetrass.svg` and `img/tetrass-dark.svg`. To choose other paths, set `TETRASS_OUTPUTS` (same multiline format as the action’s `outputs`).
 
-```bash
-export TETRASS_OUTPUTS="./out/a.svg
-./out/b.svg?palette=github-dark"
-npm run generate:tetrass
-```
-
-Offline / CI without API:
+To try the generator **without** calling the API, use a built-in sample calendar:
 
 ```bash
 TETRASS_USE_SAMPLE=1 npm run generate:tetrass
 ```
 
-Sample/offline mode uses a deterministic calendar with varied `contributionLevel` values so the animation stays non-trivial.
-
-### Tests
-
-`npm test` covers mapping, nine-band splitting, palette sanitization, SMIL `fill` timelines, and a small integration check that the sample pipeline writes an SVG with the expected grid rect count and contribution colours.
-
-CLI-only: if you intentionally run without `GITHUB_TOKEN` and want a deterministic sample when the public GraphQL request fails, set `TETRASS_ALLOW_UNAUTH_FALLBACK=1` (not recommended for workflows that should reflect real contributions).
-
-## CodeRabbit review operations (for this repo)
-
-This repository includes a Tetrass-specific CodeRabbit setup in [`.coderabbit.yaml`](.coderabbit.yaml)
-focused on:
-
-- Action contract integrity (`action/action.yml` <-> parser <-> workflow <-> README)
-- Deterministic output (same input → same SVG) and safe output paths
-- Noise reduction (generated SVG/bundle/dependency trees)
-
-Recommended local loop:
-
-```bash
-mkdir -p .coderabbit
-coderabbit --prompt-only -t uncommitted 2>&1 | tee .coderabbit/last-prompt-only.txt
-```
-
-Triage policy:
-
-- Blocking: contract breaks, path traversal risk, invariant regressions, secret leaks
-- Should-fix: docs/workflow drift, weak failure behavior
-- Nit/style: defer unless explicitly promoted
-
-Suggested pass limit: **2-3 loops max**. If the same finding repeats, refine policy text in
-`.coderabbit.yaml` instead of continuing the loop.
-
-### Warning to error escalation policy
-
-Pre-merge checks start in `warning` mode to minimize rollout friction. Promote a specific check
-to `error` only when all conditions are satisfied:
-
-1. The check has produced stable, actionable results across recent PRs (no frequent false positives).
-2. The team agrees the check should block merges.
-3. The remediation path is clear and documented in README and/or code comments.
-
-Current governance setting:
-
-- `reviews.pre_merge_checks.override_requested_reviewers_only: true`
-
-## Releasing the action
-
-The composite action lives in [`action/action.yml`](action/action.yml) and runs [`action/index.mjs`](action/index.mjs), which is produced by `npm run build` (esbuild bundle). **Commit updated `action/index.mjs` whenever TypeScript sources under `src/` change**, so consumers pinning a tag always get a working bundle without building.
-
-## Automated updates in this repository
-
-See [`.github/workflows/generate-tetrass.yml`](.github/workflows/generate-tetrass.yml): verifies `npm run build`, runs `uses: ./action`, and commits updated `img/*.svg`.
+Run `npm test` after changing code.


### PR DESCRIPTION
## Overview

Narrows README.md to what profile-repo owners need: the composite-action workflow, input table, `<picture>` embed, and optional local generation.

## Purpose

Make the default entrypoint easier to scan for consumers; keep deep invariants and maintainer context in `AGENTS.md`.

## Implementation Summary

- Reword intro for non-developer readers.
- Document default `GITHUB_TOKEN` usage and simplify the inputs table.
- Remove CodeRabbit section, action release / internal workflow notes, and the long "how it works" list from README.

## Out of scope

No changes to the composite action, source code, or `AGENTS.md` invariants.

## Notes

`.coderabbit.yaml` may still expect README/action alignment for inputs; the documented `github_user_name` and `outputs` contract is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * README を再構成し、GitHub Actions でのコンポーネント アクションの使用方法をより明確に説明しました
  * セットアップ手順とワークフロー設定ガイダンスを簡潔にしました
  * 出力形式、ローカル生成手順、埋め込み方法に関するドキュメントを改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->