### PR TITLE
fix: sample mode chunkDaysIntoWeeks week boundary

### DIFF
--- a/action/index.mjs
+++ b/action/index.mjs
@@ -97,7 +97,17 @@ async function fetchContributionCalendar(login, token) {
 }
 function chunkDaysIntoWeeks(days) {
   const weeks = [];
-  for (let i = 0; i < days.length; i += GRID_WEEKDAYS) {
+  if (days.length === 0) {
+    return { weeks };
+  }
+  let i = 0;
+  const firstWeekday = inferredWeekdayAt(days[0]);
+  if (firstWeekday !== 0) {
+    const daysUntilSunday = 7 - firstWeekday;
+    weeks.push({ contributionDays: days.slice(0, daysUntilSunday) });
+    i = daysUntilSunday;
+  }
+  for (; i < days.length; i += GRID_WEEKDAYS) {
     weeks.push({ contributionDays: days.slice(i, i + GRID_WEEKDAYS) });
   }
   return { weeks };

--- a/src/io/contributions.test.ts
+++ b/src/io/contributions.test.ts
@@ -4,6 +4,7 @@ import {
   type ContributionCalendar,
   type ContributionDay,
   buildSampleContributionDays,
+  chunkDaysIntoWeeks,
   contributionCalendarToLevelBoard,
   contributionDaysToLevelBoard,
   contributionLevelToGrassLevel,
@@ -107,7 +108,40 @@ describe("contributionDaysToLevelBoard", () => {
       contributionLevel: "SECOND_QUARTILE" as const,
     }));
     const { board } = contributionDaysToLevelBoard(days);
-    expect(board[2][52]).toBe(2);
+    // 2024-01-01 is Monday, so first week is partial (Mon-Sat, 6 days), second week has Sunday
+    // With 2 weeks total, xOffset = 53 - 2 = 51, so week 0 → x=51, week 1 → x=52
+    // Tuesday (2024-01-02, weekday=2) is in first week at x=51
+    expect(board[2][51]).toBe(2);
+  });
+
+  it("chunks days into Sunday-start weeks (Monday start input)", () => {
+    // Test case for Issue #18: Verify chunkDaysIntoWeeks aligns to GitHub's Sunday-start week boundary
+    // Input: 14 days starting from Monday (2024-01-01)
+    // Expected: First week = 6 days (Mon-Sat), Second week = 7 days (Sun-Sat), Third week = 1 day (Sun)
+    const days: ContributionDay[] = Array.from({ length: 14 }, (_, i) => {
+      const d = new Date("2024-01-01T00:00:00Z");
+      d.setUTCDate(1 + i);
+      return {
+        date: d.toISOString().slice(0, 10),
+        contributionCount: i + 1,
+        contributionLevel: "SECOND_QUARTILE" as const,
+      };
+    });
+    const cal = chunkDaysIntoWeeks(days);
+    
+    // First week should be partial (6 days: Mon-Sat)
+    expect(cal.weeks[0].contributionDays).toHaveLength(6);
+    expect(cal.weeks[0].contributionDays[0].date).toBe("2024-01-01"); // Monday
+    expect(cal.weeks[0].contributionDays[5].date).toBe("2024-01-06"); // Saturday
+    
+    // Second week should be full (7 days: Sun-Sat)
+    expect(cal.weeks[1].contributionDays).toHaveLength(7);
+    expect(cal.weeks[1].contributionDays[0].date).toBe("2024-01-07"); // Sunday
+    expect(cal.weeks[1].contributionDays[6].date).toBe("2024-01-13"); // Saturday
+    
+    // Third week should have remaining 1 day (Sunday)
+    expect(cal.weeks[2].contributionDays).toHaveLength(1);
+    expect(cal.weeks[2].contributionDays[0].date).toBe("2024-01-14"); // Sunday
   });
 
   it("maps sample days to deterministic non-trivial weekly profile", () => {

--- a/src/io/contributions.ts
+++ b/src/io/contributions.ts
@@ -111,14 +111,34 @@ export function flattenContributionDays(cal: ContributionCalendar): Contribution
 }
 
 /**
- * Wrap a flat day list into synthetic week buckets of up to 7 consecutive days (offline/sample only).
+ * Wrap a flat day list into synthetic week buckets aligned to GitHub's Sunday-start week boundary (offline/sample only).
  * Real GitHub calendars should use {@link contributionCalendarToLevelBoard} with API `weeks` as-is.
+ * 
+ * The first chunk may be a partial week (1-6 days) if the first day is not Sunday.
+ * Subsequent chunks are exactly 7 days, each starting on Sunday.
  */
 export function chunkDaysIntoWeeks(days: ContributionDay[]): ContributionCalendar {
   const weeks: { contributionDays: ContributionDay[] }[] = [];
-  for (let i = 0; i < days.length; i += GRID_WEEKDAYS) {
+  if (days.length === 0) {
+    return { weeks };
+  }
+
+  let i = 0;
+  
+  // Handle the first partial week: find the first Sunday
+  const firstWeekday = inferredWeekdayAt(days[0]!);
+  if (firstWeekday !== 0) {
+    // First day is not Sunday, create a partial first week
+    const daysUntilSunday = 7 - firstWeekday;
+    weeks.push({ contributionDays: days.slice(0, daysUntilSunday) });
+    i = daysUntilSunday;
+  }
+  
+  // Chunk the rest into 7-day weeks starting on Sunday
+  for (; i < days.length; i += GRID_WEEKDAYS) {
     weeks.push({ contributionDays: days.slice(i, i + GRID_WEEKDAYS) });
   }
+  
   return { weeks };
 }
 


### PR DESCRIPTION
## Bug Fix

### Changes
- ✅ Fixed Sunday week start boundary
- ✅ Updated date calculation to align with GitHub's Sunday-start weeks
- ✅ First partial week (1-6 days) when input doesn't start on Sunday
- ✅ Added test case for Monday-start input verifying Sunday-aligned chunks

### Verification
- All 58 tests pass
- Build succeeds

Fixes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
- 貢献カレンダーにおける週の日付配置を修正しました。カレンダーは日曜日開始の週に正しく整列するようになり、貢献度がより正確にカレンダーグリッド上に表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/daisukekarasawa/tetrass/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->